### PR TITLE
fix perkLevel() for Babele

### DIFF
--- a/system/src/documents/FalloutActor.mjs
+++ b/system/src/documents/FalloutActor.mjs
@@ -101,9 +101,11 @@ export default class FalloutActor extends Actor {
 	perkLevel(perkName) {
 		if (!["character", "robot"].includes(this.type)) return 0;
 
-		const perk = this.items.find(i => i.type === "perk"
-			&& i.name.toLowerCase() === perkName.toLowerCase()
-		);
+		const perk = this.items.find(i => {
+			const hasBabeleTranslation = i.flags?.babele?.hasTranslation === true;
+			const nameToCompare = hasBabeleTranslation ? i.flags.babele.originalName : i.name;
+			return i.type === "perk" && nameToCompare.toLowerCase() === perkName.toLowerCase();
+		});
 
 		return perk?.system?.rank?.value ?? 0;
 	}


### PR DESCRIPTION
I was testing the new junk system and the perk "scrapper" was never used.
In fact, i use **Babele** to translate my compendiums and I realized that the "name" of an item had the value of the translation of babele and not the original name.
The find() on "scrapper" therefore does not work.

There is a fix for that.
